### PR TITLE
skip cooldown after getUpdates timeout

### DIFF
--- a/lib/bot.ex
+++ b/lib/bot.ex
@@ -240,6 +240,9 @@ defmodule Telegram.Bot do
       {:ok, updates} ->
         updates
 
+      {:error, :timeout} ->
+        wait_updates(context)
+
       {:error, reason} ->
         cooldown(
           @on_error_retry_quiet_period,


### PR DESCRIPTION
IMO timeout on getUpdates with long polling shouldn't be considered an error and there's no reason to make a delay before next update and log warnings.
(btw It seems like telegram ignores timeout option and returns timeout after 30 sec no matter what value for timeout is set)