### PR TITLE
Move tesla adapter to config

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -8,12 +8,6 @@ defmodule Telegram.Client do
 
   use Tesla, only: [:get, :post], docs: false
 
-  if Mix.env() == :test do
-    adapter Tesla.Mock
-  else
-    adapter Tesla.Adapter.Gun, timeout: 60_000, connect_timeout: 5_000, certificates_verification: true
-  end
-
   plug Tesla.Middleware.BaseUrl, @api_base_url
   plug Tesla.Middleware.JSON
   plug Tesla.Middleware.Retry


### PR DESCRIPTION
Delete tesla adapter config from client.ex for the opportunity to config from config files.