### PR TITLE
remove token from logger metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The state here refer to a specific chat, a conversation (chat_id) between a user
 
 ## Logging
 
-The library attach two metadata fields to the internal logs: [:bot, :token, :chat_id].
+The library attach two metadata fields to the internal logs: [:bot, :chat_id].
 If your app run more that one bot these fields can be included in your logs (ref. to the Logger config)
 to clearly identify and "trace" every BOT message flow.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :logger, :console, metadata: [:bot, :token]
+config :logger, :console, metadata: [:bot, :chat_id]
 
 if config_env() == :test do
   config :telegram,

--- a/lib/bot/chat_bot/chat/session/server.ex
+++ b/lib/bot/chat_bot/chat/session/server.ex
@@ -41,7 +41,7 @@ defmodule Telegram.Bot.ChatBot.Chat.Session.Server do
 
   @impl GenServer
   def init({chatbot_behaviour, token, %{"id" => chat_id} = chat}) do
-    Logger.metadata(bot: chatbot_behaviour, token: token, chat_id: chat_id)
+    Logger.metadata(bot: chatbot_behaviour, chat_id: chat_id)
 
     state = %State{token: token, chatbot_behaviour: chatbot_behaviour, chat_id: chat_id, bot_state: nil}
 

--- a/lib/poller.ex
+++ b/lib/poller.ex
@@ -79,7 +79,7 @@ defmodule Telegram.Poller.Task do
   @doc false
   @spec run(module(), Types.token()) :: no_return()
   def run(bot_behaviour_module, token) do
-    Logger.metadata(bot: bot_behaviour_module, token: token)
+    Logger.metadata(bot: bot_behaviour_module)
     Logger.info("Running in polling mode")
 
     set_polling(token)


### PR DESCRIPTION
Thank you very much for the handy library!

The telegram token is secret information, so I think it would be better to remove it from the logger metadata.