### PR TITLE
Add handle_info/4 callback to Telegram.ChatBot behavior

### DIFF
--- a/lib/chat_bot.ex
+++ b/lib/chat_bot.ex
@@ -45,13 +45,20 @@ defmodule Telegram.ChatBot do
     end
 
     @impl Telegram.ChatBot
+    def handle_info(msg, _token, _chat_id, count_state) do
+      # direct message processing
+
+      {:ok, count_state}
+    end
+
+    @impl Telegram.ChatBot
     def handle_timeout(token, chat_id, count_state) do
       Telegram.Api.request(token, "sendMessage",
         chat_id: chat_id,
         text: "See you!"
       )
 
-      super(token, chat_id, count_state)
+      {:stop, count_state}
     end
   end
   ```
@@ -84,6 +91,8 @@ defmodule Telegram.ChatBot do
               | {:stop, next_chat_state :: chat_state()}
   @doc """
   On timeout callback.
+
+  This callback is optional.
   A default implementation is injected with "use Telegram.ChatBot", it just stops the bot.
   """
   @callback handle_timeout(token :: Types.token(), chat_id :: String.t(), chat_state :: chat_state()) ::
@@ -93,11 +102,18 @@ defmodule Telegram.ChatBot do
 
   @doc """
   On handle_info callback.
+
+  Can be used to implement bots that act on scheduled events (using `Process.send/3` and `Process.send_after/4`) or to interact via direct message to a a specific chat session (using `lookup/2`).
+
+  This callback is optional.
+  If one is not implemented, the received message will be logged.
   """
   @callback handle_info(msg :: any(), token :: Types.token(), chat_id :: String.t(), chat_state :: chat_state()) ::
               {:ok, next_chat_state :: chat_state()}
               | {:ok, next_chat_state :: chat_state(), timeout :: timeout()}
               | {:stop, next_chat_state :: chat_state()}
+
+  @optional_callbacks handle_info: 4, handle_timeout: 3
 
   @doc false
   defmacro __using__(_use_opts) do
@@ -105,12 +121,21 @@ defmodule Telegram.ChatBot do
       @behaviour Telegram.ChatBot
       @behaviour Telegram.Bot.Dispatch
 
+      require Logger
+
+      @impl Telegram.ChatBot
+      def handle_info(msg, _token, _chat_id, chat_state) do
+        Logger.error("#{inspect(__MODULE__)} received unexpected message in handle_info/4: #{inspect(msg)}~n")
+
+        {:ok, chat_state}
+      end
+
       @impl Telegram.ChatBot
       def handle_timeout(token, chat_id, chat_state) do
         {:stop, chat_state}
       end
 
-      defoverridable handle_timeout: 3
+      defoverridable handle_info: 4, handle_timeout: 3
 
       @spec child_spec(Types.bot_opts()) :: Supervisor.child_spec()
       def child_spec(token: token, max_bot_concurrency: max_bot_concurrency) do
@@ -124,5 +149,16 @@ defmodule Telegram.ChatBot do
         :ok
       end
     end
+  end
+
+  @doc """
+  Lookups the pid of a specific chat session.
+
+  It is up to the user to define and keep a mapping between
+  the business logic specific session identifier and the telegram chat_id.
+  """
+  @spec lookup(Types.token(), String.t()) :: {:error, :not_found} | {:ok, pid}
+  def lookup(token, chat_id) do
+    Chat.Registry.lookup(token, chat_id)
   end
 end

--- a/lib/chat_bot.ex
+++ b/lib/chat_bot.ex
@@ -91,6 +91,14 @@ defmodule Telegram.ChatBot do
               | {:ok, next_chat_state :: chat_state(), timeout :: timeout()}
               | {:stop, next_chat_state :: chat_state()}
 
+  @doc """
+  On handle_info callback.
+  """
+  @callback handle_info(msg :: any(), token :: Types.token(), chat_id :: String.t(), chat_state :: chat_state()) ::
+              {:ok, next_chat_state :: chat_state()}
+              | {:ok, next_chat_state :: chat_state(), timeout :: timeout()}
+              | {:stop, next_chat_state :: chat_state()}
+
   @doc false
   defmacro __using__(_use_opts) do
     quote location: :keep do

--- a/test/chat_bot_info_test.exs
+++ b/test/chat_bot_info_test.exs
@@ -1,0 +1,49 @@
+defmodule Test.Telegram.ChatBotInfo do
+  use ExUnit.Case, async: false
+
+  alias Test.Webhook
+  import Test.Utils.{Const, Mock}
+
+  setup_all do
+    Test.Utils.Mock.tesla_mock_global_async()
+    :ok
+  end
+
+  setup [:setup_test_bot]
+
+  test "info message" do
+    url_test_response = tg_url(tg_token(), "testResponse")
+
+    chat_id = "chat_id"
+
+    assert {:ok, _} =
+             Webhook.update(tg_token(), %{
+               "update_id" => 1,
+               "message" => %{"text" => "/command", "chat" => %{"id" => chat_id}}
+             })
+
+    assert :ok ==
+             tesla_mock_expect_request(
+               %{method: :post, url: ^url_test_response},
+               fn %{body: _body} ->
+                 response = %{"ok" => true, "result" => "ok"}
+                 Tesla.Mock.json(response, status: 200)
+               end,
+               false
+             )
+
+    {:ok, pid} = Telegram.ChatBot.lookup(tg_token(), chat_id)
+
+    send(pid, {:test, self()})
+
+    assert_receive :ok
+  end
+
+  defp setup_test_bot(_context) do
+    config = [set_webhook: false, host: "host.com"]
+    bots = [{Test.ChatBotInfo, [token: tg_token(), max_bot_concurrency: 1]}]
+    start_supervised!({Telegram.Webhook, config: config, bots: bots})
+
+    :ok
+  end
+end

--- a/test/support/test_chatbot_info.ex
+++ b/test/support/test_chatbot_info.ex
@@ -1,0 +1,23 @@
+defmodule Test.ChatBotInfo do
+  @moduledoc false
+
+  use Telegram.ChatBot
+
+  @impl Telegram.ChatBot
+  def init(_chat) do
+    {:ok, nil}
+  end
+
+  @impl Telegram.ChatBot
+  def handle_update(%{"message" => %{"chat" => %{"id" => chat_id}}}, token, nil) do
+    Telegram.Api.request(token, "testResponse", chat_id: chat_id, text: "ok")
+
+    {:ok, nil}
+  end
+
+  @impl Telegram.ChatBot
+  def handle_info({:test, pid}, _token, _chat_id, nil) do
+    send(pid, :ok)
+    {:ok, nil}
+  end
+end


### PR DESCRIPTION
* This is helpful to implement bots that act on scheduled events (using Process.send and Process.send_after)