### PR TITLE
Fix pattern match in child_spec

### DIFF
--- a/lib/bot.ex
+++ b/lib/bot.ex
@@ -46,7 +46,10 @@ defmodule Telegram.Bot do
       @behaviour Telegram.Bot.Dispatch
 
       @spec child_spec(Types.bot_opts()) :: Supervisor.child_spec()
-      def child_spec(token: token, max_bot_concurrency: max_bot_concurrency) do
+      def child_spec(bot_opts) do
+        token = Keyword.fetch!(bot_opts, :token)
+        max_bot_concurrency = Keyword.fetch!(bot_opts, :max_bot_concurrency)
+
         supervisor_name = Utils.name(__MODULE__, token)
         Supervisor.child_spec({Task.Supervisor, name: supervisor_name, max_children: max_bot_concurrency}, [])
       end

--- a/lib/chat_bot.ex
+++ b/lib/chat_bot.ex
@@ -156,7 +156,10 @@ defmodule Telegram.ChatBot do
       defoverridable handle_resume: 1, handle_info: 4, handle_timeout: 3
 
       @spec child_spec(Types.bot_opts()) :: Supervisor.child_spec()
-      def child_spec(token: token, max_bot_concurrency: max_bot_concurrency) do
+      def child_spec(bot_opts) do
+        token = Keyword.fetch!(bot_opts, :token)
+        max_bot_concurrency = Keyword.fetch!(bot_opts, :max_bot_concurrency)
+
         id = Utils.name(__MODULE__, token)
 
         Supervisor.child_spec({Chat.Supervisor, {token, max_bot_concurrency}}, id: id)


### PR DESCRIPTION
Hi @visciang 

Found an annoying bug in `Bot.child_spec/1` & `ChatBot.child_spec/1` that leads to a matching error like this.
```
** (Mix) Could not start application test: Test.Application.start(:normal, []) returned an error: shutdown: failed to start child: Telegram.Poller
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Test.Bot.child_spec/1
            (chef 0.1.0) lib/bot.ex:2: Test.Bot.child_spec([max_bot_concurrency: 1000, token: "test"])
            (elixir 1.14.2) lib/supervisor.ex:696: Supervisor.init_child/1
            (elixir 1.14.2) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
            (elixir 1.14.2) lib/supervisor.ex:687: Supervisor.init/2
            (stdlib 4.2) supervisor.erl:330: :supervisor.init/1
            (stdlib 4.2) gen_server.erl:851: :gen_server.init_it/2
            (stdlib 4.2) gen_server.erl:814: :gen_server.init_it/6
            (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```
You can read more in [this](https://hexdocs.pm/elixir/1.12/Keyword.html#module-duplicate-keys-and-ordering) section of the documentation.
In any case, I'll create a request that fixes the problem.

I will be glad if you accept it